### PR TITLE
1 newer gcc compilers fail to compile do to missing getenv prototype

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,9 +47,6 @@ jobs:
           gcc
           make
           mingw-w64-x86_64-texlive-core
-          mingw-w64-x86_64-texlive-latex
-          mingw-w64-x86_64-texlive-latexextra
-          mingw-w64-x86_64-texlive-fontsrecommended
         # pacboy: >-
         #   texlive-bin:p
         #   texlive-core:p

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,10 @@ jobs:
         pacman -Fy
         pacman -F makeinfo
         pacman -F texi2pdf
+        gcc --version
+        make --version
+        makeinfo --version
+        texi2pdf --version
 
     - name: '🚧 Build numdiff'
       if: steps.cache-numdiff.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,9 +46,9 @@ jobs:
         install: >-
           gcc
           make
-          texinfo
-          texinfo-tex
-          texlive
+          texlive-core
+          texlive-latex
+          texlive-latexextra
         # pacboy: >-
         #   texlive-bin:p
         #   texlive-core:p

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,7 @@ jobs:
           make
           texinfo
           texinfo-tex
+          mingw-w64-i686-texlive-core
           mingw-w64-x86_64-texlive-core
         # pacboy: >-
         #   texlive-bin:p

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,8 @@ jobs:
         install: >-
           gcc
           make
+          texinfo
+          texinfo-tex
           mingw-w64-x86_64-texlive-core
         # pacboy: >-
         #   texlive-bin:p

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,7 @@ jobs:
           make
           texinfo
           texinfo-tex
+          texlive
         # pacboy: >-
         #   texlive-bin:p
         #   texlive-core:p

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,9 +46,10 @@ jobs:
         install: >-
           gcc
           make
-          texlive-core
-          texlive-latex
-          texlive-latexextra
+          mingw-w64-x86_64-texlive-core
+          mingw-w64-x86_64-texlive-latex
+          mingw-w64-x86_64-texlive-latexextra
+          mingw-w64-x86_64-texlive-fontsrecommended
         # pacboy: >-
         #   texlive-bin:p
         #   texlive-core:p

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
       run: |
         mkdir _build
         cd _build
-        ../configure --disable-nls --prefix $(cygpath "${{ runner.workspace }}/${{ matrix.sys }}/${{ matrix.sys }}")
+        ../configure CFLAGS="-std=gnu17" --disable-nls --prefix $(cygpath "${{ runner.workspace }}/${{ matrix.sys }}/${{ matrix.sys }}")
         make -j2
         make install
         # cp $(which libgmp-10.dll)  $(cygpath "${{ runner.workspace }}/${{ matrix.sys }}/${{ matrix.sys }}")/bin/.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         include:
           # - { icon: '🟠', sys: clang32 }
-          - { icon: '⚫', sys: mingw32 }
+          # - { icon: '⚫', sys: mingw32 }
           - { icon: '🟦', sys: mingw64 }
           # - { icon: '🟨', sys: ucrt64  }
           # - { icon: '🟧', sys: clang64 }
@@ -48,7 +48,6 @@ jobs:
           make
           texinfo
           texinfo-tex
-          mingw-w64-i686-texlive-core
           mingw-w64-x86_64-texlive-core
         # pacboy: >-
         #   texlive-bin:p


### PR DESCRIPTION
Fix for missing getenv proto